### PR TITLE
Load external libraries over HTTPS to fix heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "map",
     "pew"
   ],
-  "repository": "https://github.com/datapsi/pewpew.git",
+  "repository": "https://github.com/hydrosquall/pewpew.git",
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-php"

--- a/index.html
+++ b/index.html
@@ -95,11 +95,11 @@ body {
 
 </style>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
-<script src="http://d3js.org/d3.geo.projection.v0.min.js"></script>
-<script src="http://d3js.org/topojson.v1.min.js"></script>
-<script src="http://datamaps.github.io/scripts/datamaps.world.min.js?v=1"></script>
-<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
+<script src="https://d3js.org/d3.geo.projection.v0.min.js"></script>
+<script src="https://d3js.org/topojson.v1.min.js"></script>
+<script src="https://datamaps.github.io/scripts/datamaps.world.min.js?v=1"></script>
+<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="jquery.simplemodal-1.4.4.js"></script>
 
 <script>


### PR DESCRIPTION
Without this fix, the `deploy-to-heroku` button's deployment won't load external javascript properly.